### PR TITLE
some refactoring of the overload macro

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,16 +6,15 @@ version = "0.3"
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 CpuId = "adafc99b-e345-5852-983c-f28acb93d879"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
-SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 BinaryProvider = "0.5.8"
 CpuId = "0.2"
-SpecialFunctions = "0.8, 0.9, 0.10"
 julia = "0.7, 1.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [targets]
-test = ["Test"]
+test = ["Test", "SpecialFunctions"]

--- a/test/real.jl
+++ b/test/real.jl
@@ -17,7 +17,7 @@ fns = [[x[1:2] for x in base_unary_real]; [x[1:2] for x in base_binary_real]]
 @testset "Definitions and Comparison with Base for Reals" begin
 
   for t in (Float32, Float64), i = 1:length(fns)
-    base_fn = eval(:($(fns[i][1]).$(fns[i][2]))) 
+    base_fn = eval(:($(fns[i][1]).$(fns[i][2])))
     vml_fn = eval(:(IntelVectorMath.$(fns[i][2])))
     vml_fn! = eval(:(IntelVectorMath.$(Symbol(fns[i][2], !))))
 
@@ -28,10 +28,10 @@ fns = [[x[1:2] for x in base_unary_real]; [x[1:2] for x in base_binary_real]]
     Test.@test vml_fn(input[t][i]...) ≈ baseres
 
     # cis changes type (float to complex, does not have mutating function)
-    
+
 
     if length(input[t][i]) == 1
-      if fns[i][2] != :cis 
+      if fns[i][2] != :cis
         vml_fn!(input[t][i]...)
         Test.@test input[t][i][1] ≈ baseres
       end
@@ -60,15 +60,17 @@ end
 
 end
 
-@testset "@overload macro" begin
-
+@testset "@vml_overload macro" begin
     @test IntelVectorMath.exp([1.0]) ≈ exp.([1.0])
     @test_throws MethodError Base.exp([1.0])
-    @test (@overload log exp) isa String
+    @vml_overload Base.log Base.exp
     @test Base.exp([1.0]) ≈ exp.([1.0])
 
     @test_throws MethodError Base.atan([1.0], [2.0])
-    @test (@overload atan) isa String
+    @vml_overload Base.atan
     @test Base.atan([1.0], [2.0]) ≈ atan.([1.0], [2.0])
 
+    @test_throws MethodError SpecialFunctions.erfc([1.0, 2.0])
+    @vml_overload SpecialFunctions.erfc
+    @test SpecialFunctions.erfc([1.0, 2.0]) ≈ SpecialFunctions.erfc.([1.0, 2.0])
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Test
 using IntelVectorMath
+using SpecialFunctions
 
 include("common.jl")
 include("real.jl")


### PR DESCRIPTION
- call it `@vml_overload` instead of just `@overload` since it is exported and `@overload` is a very generic name
- no longer overload on `Array` but only on `Vector`. Calling it on `Array` meant it included matrices and gave different semantics for e.g. `exp(M::Matrix)`. That can break existing code and is just not acceptable.
- Constraint the element types for those that are applicable to the function, so e.g. `exp(::Vector{BigInt})` will no longer try to call VML.
- Require one to give the module for what to overload in, e.g. `@vml_overload Base.exp` for the same reason one has to write `Base.exp` when overloading something locally. This means that there is no need to depend on SpecialFunctions anymore.