### PR TITLE
tweak the tests a bit

### DIFF
--- a/test/common.jl
+++ b/test/common.jl
@@ -1,57 +1,57 @@
 using SpecialFunctions
 const base_unary_real = (
-    (:Base, :acos, (-1, 1)),
-    (:Base, :asin, (-1, 1)),
-    (:Base, :atan, (-50, 50)),
-    (:Base, :cos, (-1000, 1000)),
-    (:Base, :sin, (-1000, 1000)),
-    (:Base, :tan, (-1000, 1000)),
-    (:Base, :acosh, (1, 1000)),
-    (:Base, :asinh, (-1000, 1000)),
-    (:Base, :atanh, (-1, 1)),
-    (:Base, :cosh, (0, 89.415985f0)),
-    (:Base, :sinh, (-89.415985f0, 89.415985f0)),
-    (:Base, :tanh, (-8.66434f0, 8.66434f0)),
-    (:Base, :cbrt, (-1000, 1000)),
-    (:Base, :sqrt, (0, 1000)),
-    (:Base, :exp, (-88.72284f0, 88.72284f0)),
-    (:Base, :expm1, (-88.72284f0, 88.72284f0)),
-    (:Base, :log, (0, 1000)),
-    (:Base, :log10, (0, 1000)),
-    (:Base, :log1p, (-1, 1000)),
-    (:Base, :abs, (-1000, 1000)),
-    (:Base, :abs2, (-1000, 1000)),
-    (:Base, :ceil, (-1000, 1000)),
-    (:Base, :floor, (-1000, 1000)),
-    (:Base, :round, (-1000, 1000)),
-    (:Base, :trunc, (-1000, 1000)),
-    (:Base, :cis, (-1000, 1000)),
-    (:SpecialFunctions, :erf, (-3.8325067f0, 3.8325067f0)),
-    (:SpecialFunctions, :erfc, (-3.7439213f0, 10.019834f0)),
-    (:SpecialFunctions, :erfinv, (-1, 1)),
-    (:SpecialFunctions, :erfcinv, (0, 2)),
-    (:SpecialFunctions, :lgamma, (0, 1000)),
-    (:SpecialFunctions, :gamma, (0, 36))
+    (Base, :acos, (-1, 1)),
+    (Base, :asin, (-1, 1)),
+    (Base, :atan, (-50, 50)),
+    (Base, :cos, (-1000, 1000)),
+    (Base, :sin, (-1000, 1000)),
+    (Base, :tan, (-1000, 1000)),
+    (Base, :acosh, (1, 1000)),
+    (Base, :asinh, (-1000, 1000)),
+    (Base, :atanh, (-1, 1)),
+    (Base, :cosh, (0, 89.415985f0)),
+    (Base, :sinh, (-89.415985f0, 89.415985f0)),
+    (Base, :tanh, (-8.66434f0, 8.66434f0)),
+    (Base, :cbrt, (-1000, 1000)),
+    (Base, :sqrt, (0, 1000)),
+    (Base, :exp, (-88.72284f0, 88.72284f0)),
+    (Base, :expm1, (-88.72284f0, 88.72284f0)),
+    (Base, :log, (0, 1000)),
+    (Base, :log10, (0, 1000)),
+    (Base, :log1p, (-1, 1000)),
+    (Base, :abs, (-1000, 1000)),
+    (Base, :abs2, (-1000, 1000)),
+    (Base, :ceil, (-1000, 1000)),
+    (Base, :floor, (-1000, 1000)),
+    (Base, :round, (-1000, 1000)),
+    (Base, :trunc, (-1000, 1000)),
+    (Base, :cis, (-1000, 1000)),
+    (SpecialFunctions, :erf, (-3.8325067f0, 3.8325067f0)),
+    (SpecialFunctions, :erfc, (-3.7439213f0, 10.019834f0)),
+    (SpecialFunctions, :erfinv, (-1, 1)),
+    (SpecialFunctions, :erfcinv, (0, 2)),
+    (SpecialFunctions, :lgamma, (0, 1000)),
+    (SpecialFunctions, :gamma, (0, 36))
 )
 
 const base_binary_real = (
-    (:Base, :atan, (-1, 1), (-1, 1)),
-    (:Base, :hypot, (-1000, 1000), (-1000, 1000)),
+    (Base, :atan, (-1, 1), (-1, 1)),
+    (Base, :hypot, (-1000, 1000), (-1000, 1000)),
     # (getfield(Base, :./), (-1000, 1000), (-1000, 1000)),
     # (getfield(Base, :.^), (0, 100), (-5, 20))
 )
 
 const base_unary_complex = (
-    (:Base, :acos, (-1, 1)),
-    (:Base, :asin, (-1, 1)),
-    (:Base, :acosh, (1, 1000)),
-    (:Base, :asinh, (-1000, 1000)),
-    (:Base, :sqrt, (0, 1000)),
-    (:Base, :exp, (-88.72284f0, 88.72284f0)),
-    (:Base, :log, (0, 1000)),
-    (:Base, :abs, (-1000, 1000)),
-    (:Base, :angle, (-1000, 1000)),
-    (:Base, :conj, (-1000, 1000)),
+    (Base, :acos, (-1, 1)),
+    (Base, :asin, (-1, 1)),
+    (Base, :acosh, (1, 1000)),
+    (Base, :asinh, (-1000, 1000)),
+    (Base, :sqrt, (0, 1000)),
+    (Base, :exp, (-88.72284f0, 88.72284f0)),
+    (Base, :log, (0, 1000)),
+    (Base, :abs, (-1000, 1000)),
+    (Base, :angle, (-1000, 1000)),
+    (Base, :conj, (-1000, 1000)),
     # (atan, (-50, 50)),
     # (cos, (-10, 10)),
     # (sin, (-10, 10)),
@@ -74,11 +74,7 @@ function randindomain(t::Type{T}, n, domain) where {T<:Real}
     d2 = convert(t, domain[2])
     ddiff = d2 - d1
     @assert isfinite(ddiff)
-    v = rand(t, n)
-    for i = 1:length(v)
-        v[i] = v[i]*ddiff+d1
-    end
-    v
+    return rand(t, n) .* ddiff .+ d1
 end
 
 function randindomain(t::Type{T}, n, domain) where {T<:Complex}
@@ -86,10 +82,5 @@ function randindomain(t::Type{T}, n, domain) where {T<:Complex}
     d2 = convert(t, domain[2])
     ddiff = d2 - d1
     @assert isfinite(ddiff)
-    v = rand(t, 2*n)
-    for i = 1:length(v)
-        v[i] = v[i]*ddiff+d1
-    end
-    v
-    # reinterpret(t, v)
+    return rand(t, 2*n) .* ddiff .+ d1
 end

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1,12 +1,12 @@
 # First generate some random data and test functions in Base on it
-const NVALS = 1000
+const NVALS_complex = 1000
 
-input = Dict(
-    t=>[ (randindomain(t, NVALS, domain),) for (_, _, domain) in base_unary_complex ]
+const input_complex = Dict(
+    t=>[ (randindomain(t, NVALS_complex, domain),) for (_, _, domain) in base_unary_complex ]
         for t in (ComplexF32, ComplexF64)
 )
 
-fns = [x[1:2] for x in base_unary_complex]
+const fns_complex = [x[1:2] for x in base_unary_complex]
 
 # output = Dict(
 #     t=>[ fns[i](input[t][i]...) for i = 1:length(fns) ]
@@ -14,27 +14,27 @@ fns = [x[1:2] for x in base_unary_complex]
 # )
 
 @testset "Definitions and Comparison with Base for Complex" begin
+  for t in (ComplexF32, ComplexF64), i = 1:length(fns_complex)
+    inp = input_complex[t][i]
+    mod, fn = fns_complex[i]
+    base_fn = getproperty(mod, fn)
+    vml_fn = getproperty(IntelVectorMath, fn)
+    vml_fn! = getproperty(IntelVectorMath, Symbol(fn, "!"))
 
-  for t in (ComplexF32, ComplexF64), i = 1:length(fns)
-
-    base_fn = eval(:($(fns[i][1]).$(fns[i][2]))) 
-    vml_fn = eval(:(IntelVectorMath.$(fns[i][2])))
-    vml_fn! = eval(:(IntelVectorMath.$(Symbol(fns[i][2], !))))
-
-    Test.@test which(vml_fn, typeof(input[t][i])).module == IntelVectorMath
+    Test.@test parentmodule(vml_fn) == IntelVectorMath
 
     # Test.test_approx_eq(output[t][i], fn(input[t][i]...), "Base $t $fn", "IntelVectorMath $t $fn")
-    baseres = base_fn.(input[t][i]...)
-    Test.@test vml_fn(input[t][i]...) ≈ baseres
+    baseres = base_fn.(inp...)
+    Test.@test vml_fn(inp...) ≈ base_fn.(inp...)
 
-    if length(input[t][i]) == 1
-      if fns[i][2] != :abs && fns[i][2] != :angle
-        vml_fn!(input[t][i]...)
-        Test.@test input[t][i][1] ≈ baseres
+    if inp == 1
+      if fn != :abs && fn != :angle
+        vml_fn!(inp[1])
+        Test.@test inp[1] ≈ baseres
       end
-    elseif length(input[t][i]) == 2
-      out = similar(input[t][i][1])
-      vml_fn!(out, input[t][i]...)
+    elseif length(inp) == 2
+      out = similar(inp[1])
+      vml_fn!(out, inp...)
       Test.@test out ≈ baseres
     end
 

--- a/test/real.jl
+++ b/test/real.jl
@@ -1,7 +1,7 @@
 # First generate some random data and test functions in Base on it
 const NVALS = 1000
 
-input = Dict(
+const input = Dict(
     t=>[
         [ (randindomain(t, NVALS, domain),) for (_, _, domain) in base_unary_real ];
         [ (randindomain(t, NVALS, domain1), randindomain(t, NVALS, domain2))
@@ -10,34 +10,35 @@ input = Dict(
     for t in (Float32, Float64)
 )
 
-fns = [[x[1:2] for x in base_unary_real]; [x[1:2] for x in base_binary_real]]
+const fns = [[x[1:2] for x in base_unary_real]; [x[1:2] for x in base_binary_real]]
 
 # output = Dict(t=>[fns[i](input[t][i]...) for i = 1:length(fns)] for t in (Float32, Float64))
 
 @testset "Definitions and Comparison with Base for Reals" begin
 
   for t in (Float32, Float64), i = 1:length(fns)
-    base_fn = eval(:($(fns[i][1]).$(fns[i][2]))) 
-    vml_fn = eval(:(IntelVectorMath.$(fns[i][2])))
-    vml_fn! = eval(:(IntelVectorMath.$(Symbol(fns[i][2], !))))
+  inp = input[t][i]
+    mod, fn = fns[i]
+    base_fn = getproperty(mod, fn)
+    vml_fn = getproperty(IntelVectorMath, fn)
+    vml_fn! = getproperty(IntelVectorMath, Symbol(fn, "!"))
 
-    Test.@test which(vml_fn, typeof(input[t][i])).module == IntelVectorMath
+    Test.@test parentmodule(vml_fn) == IntelVectorMath
 
     # Test.test_approx_eq(output[t][i], fn(input[t][i]...), "Base $t $fn", "IntelVectorMath $t $fn")
-    baseres = base_fn.(input[t][i]...)
-    Test.@test vml_fn(input[t][i]...) ≈ baseres
+    baseres = base_fn.(inp...)
+    Test.@test vml_fn(inp...) ≈ base_fn.(inp...)
 
     # cis changes type (float to complex, does not have mutating function)
-    
 
-    if length(input[t][i]) == 1
-      if fns[i][2] != :cis 
-        vml_fn!(input[t][i]...)
-        Test.@test input[t][i][1] ≈ baseres
+    if length(inp) == 1
+      if fn != :cis
+        vml_fn!(inp[1])
+        Test.@test inp[1] ≈ baseres
       end
-    elseif length(input[t][i]) == 2
-      out = similar(input[t][i][1])
-      vml_fn!(out, input[t][i]...)
+  elseif length(inp) == 2
+      out = similar(inp[1])
+      vml_fn!(out, inp...)
       Test.@test out ≈ baseres
     end
 


### PR DESCRIPTION
- Avoid using `eval` to get the Base and IntelVectorMath function, just give the actual module in the variable `base_unary_real` and use `getproperty` instead.
- Make some more things  `const`.
- Use `parentmodule` to check the module instead of the slightly more convoluted way with `which`.
- Create some helper variables at the beginning of the loop body to simplify some of the expressions later (since the same expression is used many times).