### PR TITLE
remove overload macro

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,21 +1,21 @@
 name = "IntelVectorMath"
 uuid = "c8ce9da6-5d36-5c03-b118-5a70151be7bc"
-version = "0.3"
+version = "0.3.0"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 CpuId = "adafc99b-e345-5852-983c-f28acb93d879"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
-SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 BinaryProvider = "0.5.8"
 CpuId = "0.2"
-SpecialFunctions = "0.8, 0.9, 0.10"
 julia = "0.7, 1.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+
 
 [targets]
-test = ["Test"]
+test = ["Test", "SpecialFunctions"]

--- a/src/IntelVectorMath.jl
+++ b/src/IntelVectorMath.jl
@@ -6,7 +6,6 @@ export IVM
 const IVM = IntelVectorMath
 
 # import Base: .^, ./
-using SpecialFunctions
 # using Libdl
 include("../deps/deps.jl")
 
@@ -104,47 +103,6 @@ for t in (Float32, Float64)
     # def_binary_op(Complex{t}, Complex{t}, :multiply_conj, :multiply_conj!, :Mul, false)
 end
 
-"""
-    @overload exp log sin
-
-This macro adds a method to each function in `Base` (or perhaps in `SpecialFunctions`),
-so that when acting on an array (or two arrays) it calls the `IntelVectorMath` function of the same name.
-
-The existing action on scalars is unaffected. However, `exp(M::Matrix)` will now mean
-element-wise `IntelVectorMath.exp(M) == exp.(M)`, rather than matrix exponentiation.
-"""
-macro overload(funs...)
-    out = quote end
-    say = []
-    for f in funs
-        if f in _UNARY
-            if isdefined(Base, f)
-                push!(out.args, :( Base.$f(A::Array) = IntelVectorMath.$f(A) ))
-                push!(say, "Base.$f(A)")
-            elseif isdefined(SpecialFunctions, f)
-                push!(out.args, :( IntelVectorMath.SpecialFunctions.$f(A::Array) = IntelVectorMath.$f(A) ))
-                push!(say, "SpecialFunctions.$f(A)")
-            else
-                @error "function IntelVectorMath.$f is not defined in Base or SpecialFunctions, so there is nothing to overload"
-            end
-        end
-        if f in _BINARY
-            if isdefined(Base, f)
-                push!(out.args, :( Base.$f(A::Array, B::Array) = IntelVectorMath.$f(A, B) ))
-                push!(say, "Base.$f(A, B)")
-            else
-                @error "function IntelVectorMath.$f is not defined in Base, so there is nothing to overload"
-            end
-        end
-        if !(f in _UNARY) && !(f in _BINARY)
-            error("there is no function $f defined by IntelVectorMath.jl")
-        end
-    end
-    str = string("Overloaded these functions: \n  ", join(say, " \n  "))
-    push!(out.args, str)
-    esc(out)
-end
-
-export VML_LA, VML_HA, VML_EP, vml_set_accuracy, vml_get_accuracy, @overload
+export VML_LA, VML_HA, VML_EP, vml_set_accuracy, vml_get_accuracy
 
 end

--- a/test/real.jl
+++ b/test/real.jl
@@ -17,7 +17,7 @@ fns = [[x[1:2] for x in base_unary_real]; [x[1:2] for x in base_binary_real]]
 @testset "Definitions and Comparison with Base for Reals" begin
 
   for t in (Float32, Float64), i = 1:length(fns)
-    base_fn = eval(:($(fns[i][1]).$(fns[i][2]))) 
+    base_fn = eval(:($(fns[i][1]).$(fns[i][2])))
     vml_fn = eval(:(IntelVectorMath.$(fns[i][2])))
     vml_fn! = eval(:(IntelVectorMath.$(Symbol(fns[i][2], !))))
 
@@ -28,10 +28,10 @@ fns = [[x[1:2] for x in base_unary_real]; [x[1:2] for x in base_binary_real]]
     Test.@test vml_fn(input[t][i]...) ≈ baseres
 
     # cis changes type (float to complex, does not have mutating function)
-    
+
 
     if length(input[t][i]) == 1
-      if fns[i][2] != :cis 
+      if fns[i][2] != :cis
         vml_fn!(input[t][i]...)
         Test.@test input[t][i][1] ≈ baseres
       end
@@ -57,18 +57,5 @@ end
 
   vml_set_accuracy(VML_EP)
   Test.@test vml_get_accuracy() == VML_EP
-
-end
-
-@testset "@overload macro" begin
-
-    @test IntelVectorMath.exp([1.0]) ≈ exp.([1.0])
-    @test_throws MethodError Base.exp([1.0])
-    @test (@overload log exp) isa String
-    @test Base.exp([1.0]) ≈ exp.([1.0])
-
-    @test_throws MethodError Base.atan([1.0], [2.0])
-    @test (@overload atan) isa String
-    @test Base.atan([1.0], [2.0]) ≈ atan.([1.0], [2.0])
 
 end


### PR DESCRIPTION
Alternative to https://github.com/JuliaMath/IntelVectorMath.jl/pull/38.

This is my preferred option. There is no need for a package like this to facilitate behavior that is explicitly recommended against in the Julia docs. If one wants to do type piracy locally, the user can just write the code for it themselves easily.