### PR TITLE
Removed the call to check_deps, a function that was not defined.

### DIFF
--- a/src/setup.jl
+++ b/src/setup.jl
@@ -1,6 +1,5 @@
 
 function __init__()
-    check_deps()
 
     Libdl.dlopen(libmkl_core, Libdl.RTLD_GLOBAL)
     Libdl.dlopen(libmkl_rt, Libdl.RTLD_GLOBAL) # maybe only needed on mac


### PR DESCRIPTION
 Calling the undefined function caused segfaults on package load on Julia master.