### PR TITLE
Allow MKL_jll 2021

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,18 +1,18 @@
 name = "IntelVectorMath"
 uuid = "c8ce9da6-5d36-5c03-b118-5a70151be7bc"
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 MKL_jll = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
 
 [compat]
 julia = "1.3"
-MKL_jll = "2020"
+MKL_jll = "2020, 2021"
+SpecialFunctions = "0.10, 1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
-
 
 [targets]
 test = ["Test", "SpecialFunctions"]

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,6 @@ MKL_jll = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
 [compat]
 julia = "1.3"
 MKL_jll = "2020, 2021"
-SpecialFunctions = "0.10, 1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
This widens the version bounds on `MKL_jll`. 

But I mark it as a draft for now, because when testing on 1.6, this happens: 
```
     Testing Running tests...
ERROR: LoadError: InitError: Artifact "MKL" is a lazy artifact; package developers must call `using LazyArtifacts` in MKL_jll before using lazy artifacts.
Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:33
  [2] _artifact_str(__module__::Module, artifacts_toml::String, name::SubString{String}, path_tail::String, artifact_dict::Dict{String, Any}, hash::Base.SHA1, platform::Base.BinaryPlatforms.Platform, lazyartifacts::Any)
    @ Artifacts ~/.julia/dev/julia/usr/share/julia/stdlib/v1.7/Artifacts/src/Artifacts.jl:547
  [3] invokelatest(::Any, ::Any, ::Vararg{Any}; kwargs::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ Base ./essentials.jl:714
  [4] invokelatest(::Any, ::Any, ::Vararg{Any})
    @ Base ./essentials.jl:712
  [5] macro expansion
    @ ~/.julia/dev/julia/usr/share/julia/stdlib/v1.7/Artifacts/src/Artifacts.jl:674 [inlined]
  [6] find_artifact_dir()
    @ MKL_jll ~/.julia/packages/JLLWrappers/KuIwt/src/wrapper_generators.jl:15
  [7] __init__()
    @ MKL_jll ~/.julia/packages/MKL_jll/SJiaS/src/wrappers/x86_64-apple-darwin.jl:9
  [8] _include_from_serialized(path::String, depmods::Vector{Any})
    @ Base ./loading.jl:670
  [9] _require_search_from_serialized(pkg::Base.PkgId, sourcepath::String)
```
I'm not too sure whether this means changes are needed here or there. 

Tests are fine on Julia 1.5, and on 1.3 says CI.